### PR TITLE
[SET-393] Code changes in hera, harmonia, cedalion triggers all jobs on Olympus

### DIFF
--- a/bash-pipeline
+++ b/bash-pipeline
@@ -20,7 +20,7 @@ pipeline {
                 }
 
                 dir('hera') {
-                  git 'https://github.com/jboss-set/hera.git'
+                  git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
                 }
 
                 dir('workdir') {

--- a/bugclerk-pipeline
+++ b/bugclerk-pipeline
@@ -10,7 +10,7 @@ pipeline {
         stage ('Build') {
             steps {
               dir('hera') {
-                git 'https://github.com/jboss-set/hera.git'
+                git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
               }
               script {
                 env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/mvn-wrapper.sh"

--- a/component-alignment-pipeline
+++ b/component-alignment-pipeline
@@ -21,11 +21,11 @@ pipeline {
                       branch: "${env.GIT_REPOSITORY_BRANCH}"
                 }
                 dir('hera') {
-                  git 'https://github.com/jboss-set/hera.git'
+                  git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
                 }
 
                 dir('harmonia') {
-                  git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git'
+                  git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git', poll: false, changelog: false
                 }
 
                 script {

--- a/cryo-pipeline
+++ b/cryo-pipeline
@@ -30,10 +30,10 @@ pipeline {
             steps {
                 cleanWs()
                 dir('hera') {
-                  git 'https://github.com/jboss-set/hera.git'
+                  git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
                 }
                 dir('harmonia') {
-                  git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git'
+                  git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git', poll: false, changelog: false
                 }
                 sh "mkdir -p workdir"
                 script {
@@ -51,7 +51,7 @@ pipeline {
                               branch: "${env.GIT_REPOSITORY_BRANCH}"
                         }
                         dir('auxilia') {
-                          git 'https://github.com/jboss-set/auxilia.git'
+                          git url: 'https://github.com/jboss-set/auxilia.git', poll: false, changelog: false
                         }
                         env.BUILD_COMMAND = "cryo"
                         env.HARMONIA_SCRIPT = "cryo.sh"

--- a/mvn-pipeline
+++ b/mvn-pipeline
@@ -10,7 +10,7 @@ pipeline {
             steps {
                 //cleanWs()
                 dir('hera') {
-                  git 'https://github.com/jboss-set/hera.git'
+                  git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
                 }
 
                 timeout(time: 10) {

--- a/pr-processor-pipeline
+++ b/pr-processor-pipeline
@@ -15,11 +15,11 @@ pipeline {
                 cleanWs()
                 script {
                     dir('hera') {
-                        git 'https://github.com/jboss-set/hera.git'
+                        git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
                     }
 
                     dir('harmonia') {
-                        git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git'
+                        git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git', poll: false, changelog: false
                     }
 
                     sh label: '', script: "mkdir -p ${env.WORKSPACE}/workdir"

--- a/wildfly-pipeline
+++ b/wildfly-pipeline
@@ -57,11 +57,11 @@ pipeline {
                       branch: "${env.GIT_REPOSITORY_BRANCH}"
                 }
                 dir('hera') {
-                  git 'https://github.com/jboss-set/hera.git'
+                  git url: 'https://github.com/jboss-set/hera.git', poll: false, changelog: false
                 }
 
                 dir('harmonia') {
-                  git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git'
+                  git branch: 'olympus', url: 'https://github.com/jboss-set/harmonia.git', poll: false, changelog: false
                 }
 
                 script {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-393

This PR tries to add `poll: false, changelog: false` to all `non-main-scm-repository` to avoid triggering by the changes in codes other than the main repository the job is focusing on.