### PR TITLE
[SET-415] Cryo jobs for 7.2.x and 7.3.x are broken

### DIFF
--- a/cryo-pipeline
+++ b/cryo-pipeline
@@ -58,6 +58,7 @@ pipeline {
                         }
                         env.BUILD_COMMAND = "cryo"
                         if ( env.HARMONIA_SCRIPT == null || "".equals("${env.HARMONIA_SCRIPT}") ) {
+                            env.CRYO_HARMONIA_SH = "eap-job.sh"
                         } else {
                             env.CRYO_HARMONIA_SH = env.HARMONIA_SCRIPT
                         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-415

`CRYO_HARMONIA_SH` is dumped to `cryo-params.sh`, but when `env.HARMONIA_SCRIPT` is not set, it will be dumped as:
```
export CRYO_HARMONIA_SH=null
```
which makes cryo job tries to run: `bash -x /var/jenkins_home/workspace/cryo-eap-7.2.x-repository-build/harmonia/null build`

Define the default `eap-job.sh` will solve the problem.