### PR TITLE
Update pull-request-processor-actives-streams to run hourly

### DIFF
--- a/jobs/pull-request-processor-actives-streams.groovy
+++ b/jobs/pull-request-processor-actives-streams.groovy
@@ -14,7 +14,7 @@ pipelineJob(ITEM_NAME) {
     JobSharedUtils.defaultBuildDiscarder(delegate)
     triggers {
         scm (JobSharedUtils.DEFAULT_SCHEDULE)
-        cron('@daily')
+        cron('@hourly')
     }
     parameters {
         JobSharedUtils.mavenParameters(params: delegate)


### PR DESCRIPTION
It seems the refactoring changed the it to a daily job.
This just update `pull-request-processor-actives-streams` job back to run hourly