### PR TITLE
JDK 11 (or greater) is required to build WildFly

### DIFF
--- a/jobs/_.groovy
+++ b/jobs/_.groovy
@@ -25,6 +25,7 @@ EapView.jobList(this, 'eap-6.4.x', 'eap-6.4.*')
 
 new eap7.Builder(branch:'main',
                  jobName: 'wildfly',
-                 gitRepositoryUrl: "git@github.com:wildfly/wildfly.git"
+                 gitRepositoryUrl: "git@github.com:wildfly/wildfly.git",
+                 javaHome: "/opt/oracle/openjdk-11.0.14.1_1"
                 ).buildAndTest(this)
 EapView.jobList(this, 'wildfly', 'wildfly.*')


### PR DESCRIPTION
Some wildfly* jobs fail on Olympus, it turns out JDK 11 (or greater) is required to build them now. 

I only found JDK 8 and JDK 17 provided, upstream has a job for "Wildfly Preview - Linux - JDK 17". So let's try LTS JDK 17.