### PR TITLE
Add javaHome property to eap7 Builder

### DIFF
--- a/job-dsl-lib/eap7/Builder.groovy
+++ b/job-dsl-lib/eap7/Builder.groovy
@@ -9,6 +9,7 @@ class Builder {
     String schedule = JobSharedUtils.DEFAULT_SCHEDULE
     String parentJobname = ''
     String mavenSettingsXml
+    String javaHome='/opt/oracle/java'
     String harmoniaScript = 'eap-job/olympus.sh'
     String gitRepositoryUrl = 'git@github.com:jbossas/jboss-eap7.git'
 
@@ -67,7 +68,7 @@ class Builder {
 
     def commonParameters(params) {
         JobSharedUtils.gitParameters(params, gitRepositoryUrl, branch)
-        JobSharedUtils.mavenParameters(params: params, mavenSettingsXml: mavenSettingsXml)
+        JobSharedUtils.mavenParameters(params: params, javaHome: javaHome, mavenSettingsXml: mavenSettingsXml)
         params.with {
             stringParam {
                 name ("HARMONIA_SCRIPT")

--- a/job-dsl-lib/util/JobSharedUtils.groovy
+++ b/job-dsl-lib/util/JobSharedUtils.groovy
@@ -33,6 +33,10 @@ class JobSharedUtils {
             args.mavenSettingsXml = '/opt/tools/settings.xml'
         }
 
+        if (args.javaHome == null) {
+            args.javaHome = '/opt/oracle/java'
+        }
+
         args.params.with {
             stringParam {
                 name ("MAVEN_HOME")
@@ -40,7 +44,7 @@ class JobSharedUtils {
             }
             stringParam {
                 name ("JAVA_HOME")
-                defaultValue("/opt/oracle/java")
+                defaultValue(args.javaHome)
             }
             stringParam {
                 name ("MAVEN_SETTINGS_XML")


### PR DESCRIPTION
Quick fix for `ERROR: (script, line 26) No such property: javaHome for class: eap7.Builder` in `job-configurator` 

caused by https://github.com/jboss-set/cedalion/pull/27

