### PR TITLE
[SET-493] Support customized parameters in cedalion

### DIFF
--- a/job-dsl-lib/eap7/Builder.groovy
+++ b/job-dsl-lib/eap7/Builder.groovy
@@ -12,6 +12,7 @@ class Builder {
     String javaHome='/opt/oracle/java'
     String harmoniaScript = 'eap-job/olympus.sh'
     String gitRepositoryUrl = 'git@github.com:jbossas/jboss-eap7.git'
+    def customParams
 
     def buildAndTest(factory) {
         build(factory)
@@ -39,6 +40,9 @@ class Builder {
                 }
                 parameters {
                     commonParameters(delegate)
+                    if (customParams != null) {
+                        JobSharedUtils.customParams(delegate, customParams)
+                    }
                 }
             }
         }
@@ -60,6 +64,9 @@ class Builder {
                     stringParam {
                         name("PARENT_JOBNAME")
                         defaultValue(parentJobname)
+                    }
+                    if (customParams != null) {
+                        JobSharedUtils.customParams(delegate, customParams)
                     }
                 }
             }

--- a/job-dsl-lib/util/JobSharedUtils.groovy
+++ b/job-dsl-lib/util/JobSharedUtils.groovy
@@ -92,4 +92,10 @@ class JobSharedUtils {
             env('PATH', '$PATH:$MAVEN_HOME/bin')
         }
     }
+
+    static customParams(def params, def customParams) {
+        customParams.delegate = params
+        customParams.resolveStrategy = Closure.DELEGATE_FIRST
+        customParams.call()
+    }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-493

With this change, the following job definition can produce an extra parameter definition:

```
new eap7.Builder(branch:'7.4.x', customParams: {
    stringParam {
        name("TESTSUITE_OPTS")
        defaultValue("-Delytron")
    }
}).test(this)
```
it will produce a new parameter:
```
Parameter name:                TESTSUITE_OPTS
Parameter defaultValue:        -Delytron
```