### PR TITLE
[SET-497] Export job's the parameters to a file and pass it to job.sh in hera

### DIFF
--- a/pipelines/ansible-ci-pipeline
+++ b/pipelines/ansible-ci-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -38,8 +47,9 @@ pipeline {
                 script {
                     env.BUILD_SCRIPT = "${env.WORKSPACE}/harmonia/${env.PATH_TO_SCRIPT}"
                     env.WORKDIR = "${env.WORKSPACE}/workdir/"
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                     sh label: '', script: "${env.WORKSPACE}/hera/hera.sh run"
-                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                     archiveArtifacts artifacts: 'workdir/**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                     findText(textFinders: [
                         textFinder(regexp: /MOLECULE_EXIT_CODE/, alsoCheckConsoleOutput: true, buildResult: 'UNSTABLE', changeCondition: 'MATCH_FOUND'),

--- a/pipelines/ansible-pipeline
+++ b/pipelines/ansible-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -34,8 +43,9 @@ pipeline {
                 script {
                     env.BUILD_SCRIPT = "${env.WORKSPACE}/harmonia/${env.PATH_TO_SCRIPT}"
                     env.WORKDIR = "${env.WORKSPACE}/workdir/"
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                     sh label: '', script: "${env.WORKSPACE}/hera/hera.sh run"
-                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                     archiveArtifacts artifacts: 'workdir/**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                }
            }

--- a/pipelines/bash-pipeline
+++ b/pipelines/bash-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -31,8 +40,9 @@ pipeline {
                 script {
                     env.BUILD_SCRIPT = "${env.WORKSPACE}/workdir/${env.PATH_TO_SCRIPT}"
                     env.WORKDIR = "${env.WORKSPACE}/workdir/"
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                     sh label: '', script: "${env.WORKSPACE}/hera/hera.sh run"
-                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                     archiveArtifacts artifacts: 'workdir/**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                     step([$class: "TapPublisher", testResults: "workdir/*.tap"])
                     publishHTML([allowMissing: true, alwaysLinkToLastBuild: false, keepAll: false, reportDir: 'workdir', reportFiles: 'shellcheck.html', reportName: 'Shellcheck Report', reportTitles: ''])

--- a/pipelines/bugclerk-pipeline
+++ b/pipelines/bugclerk-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
     triggers { cron("@hourly") }
@@ -16,8 +25,9 @@ pipeline {
                 env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/mvn-wrapper.sh"
                 git url: "${env.GIT_REPOSITORY_URL}",
                     branch: "${env.GIT_REPOSITORY_BRANCH}"
+                dumpParams("${env.WORKSPACE}/job_params.txt")
                 sh label: '', script: "${env.WORKSPACE}/hera/hera.sh run"
-                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: false, reportDir: '.', reportFiles: 'bugclerk-report.html', reportName: 'HTML Report', reportTitles: ''])
                 archiveArtifacts artifacts: '**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                 }

--- a/pipelines/cct-pipeline
+++ b/pipelines/cct-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -32,6 +41,7 @@ pipeline {
 
                 script {
                     env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/build-wrapper.sh"
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                 }
 
                 // Start container
@@ -45,7 +55,7 @@ pipeline {
                         env.NEXUS_CREDENTIALS="$nexusUsername:$nexusPassword"
                     }
                     sh label: '', script: 'pwd'
-                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                    sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                     archiveArtifacts artifacts: '**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                     findText(textFinders: [
                         textFinder(regexp: /.INFO. BUILD FAILURE/, alsoCheckConsoleOutput: true, buildResult: 'UNSTABLE', changeCondition: 'MATCH_FOUND'),

--- a/pipelines/component-alignment-pipeline
+++ b/pipelines/component-alignment-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -30,6 +39,7 @@ pipeline {
 
                 script {
                     env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/build-wrapper.sh"
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                 }
                 // Start container
                 sh label: '', script: "${env.WORKSPACE}/hera/hera.sh run"
@@ -37,7 +47,7 @@ pipeline {
         }
         stage ('Build') {
             steps {
-                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
             }
         }
     }

--- a/pipelines/mvn-pipeline
+++ b/pipelines/mvn-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -34,6 +43,7 @@ pipeline {
                           env.GIT_REPOSITORY_BRANCH = "master"
                         }
                         echo "GIT_REPOSITORY_BRANCH:[${env.GIT_REPOSITORY_BRANCH}]"
+                        dumpParams("${env.WORKSPACE}/job_params.txt")
 
                         // Start container
                         env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/mvn-wrapper.sh"
@@ -46,7 +56,7 @@ pipeline {
         }
       stage ('Build') {
             steps {
-                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                 archiveArtifacts artifacts: '**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                 junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml'
             }

--- a/pipelines/pr-processor-pipeline
+++ b/pipelines/pr-processor-pipeline
@@ -1,3 +1,12 @@
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -27,6 +36,7 @@ pipeline {
                         env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/build-wrapper.sh"
                     }
                     echo "BUILD_COMMAND: ${env.BUILD_COMMAND}"
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                     // Start container
                     sh label: '', script: "${env.WORKSPACE}/hera/hera.sh run"
                 }
@@ -34,7 +44,7 @@ pipeline {
         }
         stage ('Build') {
             steps {
-                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: false, reportDir: 'workdir', reportFiles: 'report.html', reportName: 'HTML Report', reportTitles: ''])
                 archiveArtifacts artifacts: '**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
             }

--- a/pipelines/wildfly-pipeline
+++ b/pipelines/wildfly-pipeline
@@ -15,6 +15,15 @@ def determineBuildResult() {
   ])
 }
 
+def dumpParams(String outputFile) {
+  echo "Dumping all parameters to " + outputFile
+  def lines = ""
+  params.each() { param, value ->
+    lines = lines + "${param}=\"${value}\"\n"
+  }
+  writeFile file: outputFile, text: lines
+}
+
 pipeline {
     agent any
 
@@ -68,6 +77,7 @@ pipeline {
                     if ( env.RERUN_FAILING_TESTS == null || "".equals("${env.RERUN_FAILING_TESTS}") ) {
                       env.RERUN_FAILING_TESTS = 0
                     }
+                    dumpParams("${env.WORKSPACE}/job_params.txt")
                     env.BUILD_SCRIPT = "${env.WORKSPACE}/hera/build-wrapper.sh"
                     if ( "${env.BUILD_COMMAND}".startsWith("testsuite") ) {
                         def parent_jobname = ""
@@ -94,7 +104,7 @@ pipeline {
             when { expression { env.BUILD_COMMAND == 'build' } }
             steps {
                 sh label: '', script: 'pwd'
-                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                 archiveArtifacts artifacts: '**/*', fingerprint: true, followSymlinks: false, onlyIfSuccessful: true
                 findText(textFinders: [
                     textFinder(regexp: /.INFO. BUILD FAILURE/, alsoCheckConsoleOutput: true, buildResult: 'UNSTABLE', changeCondition: 'MATCH_FOUND'),
@@ -115,7 +125,7 @@ pipeline {
             steps {
               script {
                 try {
-                  sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job"
+                  sh label: '', script: "${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt"
                 } catch (err) {
                   echo "Error during build ${err}"
                 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-497

This is the second step to make exporting job parameters as env variables work, this dumps job parameters into a file(`${env.WORKSPACE}/job_params.txt`) and pass it to the `${env.WORKSPACE}/hera/hera.sh job ${env.WORKSPACE}/job_params.txt`

This PR updates most pipelines, leaving tck and cryo pipelines untouched, because they have similar setup to save parameters to a file, leaving them untouched won't break anything.

This PR depends on https://github.com/jboss-set/hera/pull/17 to work