### PR TITLE
Downgrade default jdk for ci jobs to 11

### DIFF
--- a/job-dsl-lib/ci_jobs/Builder.groovy
+++ b/job-dsl-lib/ci_jobs/Builder.groovy
@@ -75,7 +75,7 @@ class Builder {
                     }
                     stringParam {
                         name("JAVA_HOME")
-                        defaultValue("/opt/oracle/jdk17-latest")
+                        defaultValue("/opt/oracle/jdk11")
                     }
                 }
             }


### PR DESCRIPTION
Some jobs like aphrodite don't work with JDK 17. JDK 11 should be a safer default.
