### PR TITLE
ansible: cleanup triggers

### DIFF
--- a/job-dsl-lib/ansible/JanusBuilder.groovy
+++ b/job-dsl-lib/ansible/JanusBuilder.groovy
@@ -21,9 +21,6 @@ class JanusBuilder extends AbstractAnsibleBuilder {
                     artifactDaysToKeep(60)
                     artifactNumToKeep(5)
                 }
-                triggers {
-                    setupTrigger ? upstream('ansible-ci-' + (upstreamCollectionName ?: projectUpstreamName),'FAILURE') : scm (schedule)
-                }
                 parameters {
                     stringParam {
                       name("PROJECT_NAME")

--- a/pipelines/ansible-pipeline
+++ b/pipelines/ansible-pipeline
@@ -128,10 +128,18 @@ pipeline {
         }
         success {
             script {
-              if ( isJanusJob() && ! "${env.JOB_NAME}".endsWith("runtimes_common") ) {
-                build wait: false, job: "ansible-downstream-ci-${env.PROJECT_NAME}"
-                build wait: false, job: "ansible-downstream-tests-${env.PROJECT_NAME}-dot"
-                build wait: false, job: "ansible-downstream-runner-${env.PROJECT_NAME}"
+              // The release job will take care of trigger jobs in the right order
+              if ( "${env.RELEASE_NAME}".equals("") ) {
+                // if this job is upstream CI, then we fire the associated Janus job
+                if ( "${env.JOB_NAME}".equals("ansible-ci-${env.PROJECT_UPSTREAM_NAME}") ) {
+                    build wait: false, job: "ansible-janus-${env.PROJECT_NAME}"
+                }
+                // if this jobs is a Janus job, then we triggered the three downstream job
+                if ( isJanusJob() && ! "${env.JOB_NAME}".endsWith("runtimes_common") ) {
+                  build wait: false, job: "ansible-downstream-ci-${env.PROJECT_NAME}"
+                  build wait: false, job: "ansible-downstream-tests-${env.PROJECT_NAME}-dot"
+                  build wait: false, job: "ansible-downstream-runner-${env.PROJECT_NAME}"
+                }
               }
             }
         }

--- a/pipelines/ansible-release-pipeline
+++ b/pipelines/ansible-release-pipeline
@@ -1,4 +1,4 @@
-def tagBuild(String jobname, String releaseName, String gitBranch = "main") {
+def tagBuild(String jobname, String releaseName = "TEST", String gitBranch = "main") {
     echo "Triggers ${jobname} with branch ${gitBranch}"
     def jobRunResults = build(job: "${jobname}", parameters: [string(name: 'GIT_REPOSITORY_BRANCH', value: "${gitBranch}"), string(name: 'RELEASE_NAME', value: "${releaseName}")])
     def job = Jenkins.instance.getItem("${jobname}")


### PR DESCRIPTION
- ensure release job does not triggers multiple job
- centralize all the triggers in the pipeline