### PR TITLE
[SET-723] Adds default podman container CPU and memory limitation in wildfly-pipeline

### DIFF
--- a/pipelines/wildfly-pipeline
+++ b/pipelines/wildfly-pipeline
@@ -36,6 +36,11 @@ pipeline {
         // -Dhttps.protocols=TLSv1.2 needs to move to Harmonia?
     }
 
+    environment {
+        PODMAN_CONTAINER_CPU = '4'
+        PODMAN_CONTAINER_MEMORY = '4g'
+    }
+
     stages {
         stage('Prep') {
             steps {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-723

This PR tries to add the default podman container cpu limitation to `16` and memory limitation to `16g`.

The values are picked randomly based on regular laptop setup, so they are open to change to any other values.

Another approach to add the default limitation values is through job parameters, please let me know if that is preferable. 