### PR TITLE
Update wildfly-build to use JDK 17

### DIFF
--- a/jobs/_.groovy
+++ b/jobs/_.groovy
@@ -45,6 +45,6 @@ EapView.jobList(this, 'eap-6.4.x', 'eap-6.4.*')
 new eap7.Builder(branch:'main',
                  jobName: 'wildfly',
                  gitRepositoryUrl: "git@github.com:wildfly/wildfly.git",
-                 javaHome: "/opt/oracle/openjdk11-latest"
+                 javaHome: "/opt/oracle/jdk17-latest"
                 ).buildAndTest(this)
 EapView.jobList(this, 'wildfly', 'wildfly.*')


### PR DESCRIPTION
WildFly moved to JDK 17 for building and testing. This update should take care of it.