### PR TITLE
Add MAVEN_ARGS to the building parameters

### DIFF
--- a/job-dsl-lib/ci_jobs/Builder.groovy
+++ b/job-dsl-lib/ci_jobs/Builder.groovy
@@ -77,6 +77,10 @@ class Builder {
                         name("JAVA_HOME")
                         defaultValue("/opt/oracle/jdk11")
                     }
+                    stringParam {
+                        name("MAVEN_ARGS")
+                        defaultValue("")
+                    }
                 }
             }
         }

--- a/job-dsl-lib/util/JobSharedUtils.groovy
+++ b/job-dsl-lib/util/JobSharedUtils.groovy
@@ -93,6 +93,10 @@ class JobSharedUtils {
                 name ("MAVEN_OPTS")
                 defaultValue("-Dmaven.wagon.http.ssl.insecure=true -Dhttps.protocols=TLSv1.2")
             }
+            stringParam {
+                name ("MAVEN_ARGS")
+                defaultValue("")
+            }
         }
     }
 


### PR DESCRIPTION
This should allow us to control the Maven arguments from CI, adding the possibily to use `-X`, `-Durefire.timeout`, etc.