### PR TITLE
Revert "Fix use of deprecated Jenkins API"

### DIFF
--- a/pipelines/ansible-pipeline
+++ b/pipelines/ansible-pipeline
@@ -62,7 +62,7 @@ def isRelease(String releaseName) {
 }
 
 def triggerNextJob(String jobname, String branch = "main") {
-    if (jenkins.model.Jenkins.getInstanceOrNull.getItem(jobname) != null) {
+    if (jenkins.model.Jenkins.instance.getItem(jobname) != null) {
         script {
           echo "Trigger job ${jobname}:"
           build wait: isRelease("${env.RELEASE_NAME}"),

--- a/pipelines/ansible-release-common-pipeline
+++ b/pipelines/ansible-release-common-pipeline
@@ -1,7 +1,7 @@
 def tagBuild(String jobname, String releaseName, String gitBranch = "main") {
     echo "Triggers ${jobname} with branch ${gitBranch}"
     def jobRunResults = build(job: "${jobname}",parameters: [string(name: 'GIT_REPOSITORY_BRANCH', value: "${gitBranch}")])
-    def job = Jenkins.getInstanceOrNull.getItem("${jobname}")
+    def job = Jenkins.instance.getItem("${jobname}")
     def build = job.getBuild(jobRunResults.id)
     echo "${jobname} - set release build to keep log forever"
     build.keepLog(true)
@@ -17,7 +17,7 @@ def returnPathToTarball(Collection coll) {
 }
 
 def retrievePathToJanusDownload(String jobname) {
-    def job = Jenkins.getInstanceOrNull.getItem(jobname)
+    def job = Jenkins.instance.getItem(jobname)
     def build = job.getLastBuild()
     def jobUrl = build.url
     def artifactPath = returnPathToTarball(build.artifacts)

--- a/pipelines/ansible-release-pipeline
+++ b/pipelines/ansible-release-pipeline
@@ -1,7 +1,7 @@
 def tagBuild(String jobname, String releaseName = "TEST", String gitBranch = "main") {
     echo "Triggers ${jobname} with branch ${gitBranch}"
     def jobRunResults = build(job: "${jobname}", parameters: [string(name: 'GIT_REPOSITORY_BRANCH', value: "${gitBranch}"), string(name: 'RELEASE_NAME', value: "${releaseName}")])
-    def job = Jenkins.getInstanceOrNull.getItem("${jobname}")
+    def job = Jenkins.instance.getItem("${jobname}")
     def build = job.getBuild(jobRunResults.id)
     echo "${jobname} - set release build to keep log forever"
     if ( ! "TEST".equals(releaseName) )
@@ -18,7 +18,7 @@ def returnPathToTarball(Collection coll) {
 }
 
 def retrievePathToJanusDownload(String jobname) {
-    def job = Jenkins.getInstanceOrNull.getItem(jobname)
+    def job = Jenkins.instance.getItem(jobname)
     def build = job.getLastBuild()
     def jobUrl = build.url
     def artifactPath = returnPathToTarball(build.artifacts)
@@ -27,7 +27,7 @@ def retrievePathToJanusDownload(String jobname) {
 
 def retrieveTaggedBuildURLForJob(String jobName, String releaseName) {
   def url = "Fail to retrieved absolute URL from job ${jobName} tagged ${releaseName}"
-  Jenkins.getInstanceOrNull.getItem(jobName).getBuilds().each {
+  Jenkins.instance.getItem(jobName).getBuilds().each {
     b -> if ( b.getDisplayName().equals(releaseName) ) url = b.getAbsoluteUrl()
   }
   return url


### PR DESCRIPTION
This reverts commit 3a81f97fe347b21decfc054d4ac61a0e8ffcbfb4.

@spyrkob Silly jenkins... Somehow, when I tested with jenkins.next, I got an error, but now that our Jenkins is updated, the "good" API does not seems to be there so we have to revert 😒